### PR TITLE
Fixes PHP error when trying to delete an index

### DIFF
--- a/includes/index_entity.inc
+++ b/includes/index_entity.inc
@@ -180,6 +180,25 @@ class SearchApiIndex extends Entity {
   }
 
   /**
+   * Checks if the entity has a certain exportable status.
+   *
+   * @param $status
+   *   A status constant, i.e. one of ENTITY_CUSTOM, ENTITY_IN_CODE,
+   *   ENTITY_OVERRIDDEN or ENTITY_FIXED.
+   *
+   * @return bool
+   *   For exportable entities TRUE if the entity has the status, else FALSE.
+   *   In case the entity is not exportable, NULL is returned.
+   *
+   * @see entity_has_status()
+   */
+  public function hasStatus($status) {
+    if (!empty($this->entityInfo['exportable'])) {
+      return isset($this->{$this->statusKey}) && ($this->{$this->statusKey} & $status) == $status;
+    }
+  }
+
+  /**
    * Execute necessary tasks for a newly created index.
    */
   public function postCreate() {


### PR DESCRIPTION
Error: Call to undefined method SearchApiIndex::hasStatus()
in search_api_admin_confirm() (line 2344 of /modules/search_api/search_api.admin.inc).

D7 Entity object had a method hasStatus() and backdrop core entity module
no longer contains this method but we still need it.

Source: https://git.drupalcode.org/project/entity/-/blob/7.x-1.x/includes/entity.inc
line 83