### PR TITLE
Support for exportable entity statuses.

### DIFF
--- a/includes/index_entity.inc
+++ b/includes/index_entity.inc
@@ -173,6 +173,11 @@ class SearchApiIndex extends Entity {
   public $read_only = 0;
 
   /**
+   * Status constant for exportable entities
+   */
+  public $status = ENTITY_CUSTOM;
+
+  /**
    * Constructor as a helper to the parent constructor.
    */
   public function __construct(array $values = array(), $entity_type = 'search_api_index') {

--- a/includes/server_entity.inc
+++ b/includes/server_entity.inc
@@ -72,6 +72,11 @@ class SearchApiServer extends Entity {
   protected $proxy;
 
   /**
+   * Status constant for exportable entities
+   */
+  public $status = ENTITY_CUSTOM;
+
+  /**
    * Constructor as a helper to the parent constructor.
    */
   public function __construct(array $values = array(), $entity_type = 'search_api_server') {

--- a/search_api.admin.inc
+++ b/search_api.admin.inc
@@ -66,7 +66,7 @@ function search_api_admin_overview() {
     $row = array();
     $row[] = $server->enabled ? $t_enabled : $t_disabled;
     if ($show_config_status) {
-      $row[] = theme('entity_status', array('status' => $server->status));
+      $row[] = theme('entity_plus_status', array('status' => $server->status));
     }
     $row[] = $t_server;
     $row[] = l($server->name, $url);
@@ -91,7 +91,7 @@ function search_api_admin_overview() {
         $row = array();
         $row[] = $index->enabled ? $t_enabled : $t_disabled;
         if ($show_config_status) {
-          $row[] = theme('entity_status', array('status' => $index->status));
+          $row[] = theme('entity_plus_status', array('status' => $index->status));
         }
         $row[] = ' ';
         $row[] = $t_index;
@@ -116,7 +116,7 @@ function search_api_admin_overview() {
       $row = array();
       $row[] = $t_disabled;
       if ($show_config_status) {
-        $row[] = theme('entity_status', array('status' => $index->status));
+        $row[] = theme('entity_plus_status', array('status' => $index->status));
       }
       $row[] = array(
         'data' => $t_index,
@@ -512,7 +512,7 @@ function theme_search_api_server(array $variables) {
 
   if ($status != ENTITY_CUSTOM) {
     $label = t('Configuration status');
-    $info = theme('entity_status', array('status' => $status));
+    $info = theme('entity_plus_status', array('status' => $status));
     $class = ($status == ENTITY_OVERRIDDEN) ? 'warning' : 'ok';
     $rows[] = _search_api_deep_copy($row);
     $class = '';
@@ -1089,8 +1089,8 @@ function theme_search_api_index(array $variables) {
     if ($options['cron_limit']) {
       $class = 'ok';
       $info = format_plural(
-        $options['cron_limit'], 
-        'During cron runs, 1 item will be indexed per batch.', 
+        $options['cron_limit'],
+        'During cron runs, 1 item will be indexed per batch.',
         'During cron runs, @count items will be indexed per batch.'
       );
     }
@@ -1123,7 +1123,7 @@ function theme_search_api_index(array $variables) {
 
   if ($status != ENTITY_CUSTOM) {
     $label = t('Configuration status');
-    $info = theme('entity_status', array('status' => $status));
+    $info = theme('entity_plus_status', array('status' => $status));
     $class = ($status == ENTITY_OVERRIDDEN) ? 'warning' : 'ok';
     $rows[] = _search_api_deep_copy($row);
   }
@@ -1607,7 +1607,7 @@ function search_api_admin_index_workflow(array $form, array &$form_state, Search
     '#collapsible' => TRUE,
   );
   if ($index->server) {
-    $form['processors']['#description'] .= '<p>' . t("Check the <a href='@server-url'>server's</a> service class description for details.", 
+    $form['processors']['#description'] .= '<p>' . t("Check the <a href='@server-url'>server's</a> service class description for details.",
         array('@server-url' => url('admin/config/search/search_api/server/' . $index->server . '/edit'))) . '</p>';
   }
 
@@ -1867,7 +1867,7 @@ function search_api_admin_index_fields(array $form, array &$form_state, SearchAp
         'In any case, fields of type "Fulltext" will always be fulltext-searchable.</p>'),
   );
   if ($index->server) {
-    $form['description']['#description'] .= '<p>' . t("Check the <a href='@server-url'>server's</a> service class description for details.", 
+    $form['description']['#description'] .= '<p>' . t("Check the <a href='@server-url'>server's</a> service class description for details.",
         array('@server-url' => url('admin/config/search/search_api/server/' . $index->server . '/edit'))) . '</p>';
   }
   foreach ($fields as $key => $info) {
@@ -1943,7 +1943,7 @@ function search_api_admin_index_fields(array $form, array &$form_state, SearchAp
             t('Note that indexing an entity-valued field (like %field, which has type %type) directly will only index the entity ID. ' .
             'This will be used for filtering and also sorting (which might not be what you expect). ' .
             'The entity label will usually be used when displaying the field, though. ' .
-            'Use the "Add related fields" option at the bottom for indexing other fields of related entities.', 
+            'Use the "Add related fields" option at the bottom for indexing other fields of related entities.',
             array('%field' => $info['name'], '%type' => $label)) . '</p>';
         $entity_description_added = TRUE;
       }

--- a/search_api.module
+++ b/search_api.module
@@ -278,6 +278,7 @@ function search_api_theme() {
       'indexes' => array(),
       'options' => array(),
       'extra' => array(),
+      'status' => NULL,
     ),
     'file' => 'search_api.admin.inc',
   );
@@ -297,6 +298,7 @@ function search_api_theme() {
       'on_server' => NULL,
       'total_items' => 0,
       'read_only' => 0,
+      'status' => NULL,
     ),
     'file' => 'search_api.admin.inc',
   );


### PR DESCRIPTION
We added support in the entity_plus module for statuses in exportable entities.
backdrop-contrib/entity_plus#34
This should address two PHP issues that I noticed when viewing pages showing search indices or servers.

fixes the following issues:
PHP Notice: Undefined index: status in theme_search_api_index() (line 1027 of /var/www/rvg-web.net/backdrop2/modules/search_api/search_api.admin.inc).

and

PHP Warning: Theme hook "entity_status" not found.

when viewing /admin/config/search/search_api/index/_someIndexName_